### PR TITLE
Fix duplicate text in BattleScreen splash

### DIFF
--- a/src/screens/BattleScreen.tsx
+++ b/src/screens/BattleScreen.tsx
@@ -379,7 +379,6 @@ const BattleScreen = ({ onQuit }: { onQuit: () => void }) => {
               : "Your signal fades into static. Try again, operative."}
           </p>
           <div className="mt-2 text-sm text-green-300">Returning to Main Menu...</div>
-          <div className="mt-2 text-sm text-green-300">Returning to Main Menu...</div>
         </motion.div>
       )}
 


### PR DESCRIPTION
## Summary
- remove one of the repeated "Returning to Main Menu..." lines in BattleScreen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684274552e2c832c94a3f4244dfba145