### PR TITLE
Add ability id support to runEffect

### DIFF
--- a/backend/src/match_engine/effect_runner.ts
+++ b/backend/src/match_engine/effect_runner.ts
@@ -6,7 +6,8 @@ export const runEffect = (
   effect: Effect,
   sourcePlayer: PlayerState,
   targetPlayer: PlayerState,
-  matchState: MatchState
+  matchState: MatchState,
+  abilityId: string
 ): { newMatchState: MatchState; logs: CombatLogEntry[] } => {
   let currentMatchState = { ...matchState };
   let logs: CombatLogEntry[] = [];
@@ -34,7 +35,7 @@ export const runEffect = (
           id: `stun-${Date.now()}`, // Simple unique ID
           type: 'stun',
           duration: effect.duration,
-          sourceAbilityId: '', // TODO: Pass actual ability ID
+          sourceAbilityId: abilityId,
           appliedAtTurn: currentMatchState.turnNumber,
         };
         updatedTargetPlayer = addStatusEffect(target, stunEffect);

--- a/match_resolution_engine_architecture.md
+++ b/match_resolution_engine_architecture.md
@@ -33,7 +33,7 @@
 - Loads effects from JSON ability file
 - Applies effects through handlers:
 ```ts
-runEffect({ type: 'burn', duration: 2 }, source, target, state)
+runEffect({ type: 'burn', duration: 2 }, abilityId, source, target, state)
 ```
 
 ### `status_manager.ts`


### PR DESCRIPTION
## Summary
- update `runEffect` signature to take the ability id
- apply the passed ability id when creating a stun effect
- update documentation example

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842746ce744832cb4951ad6436bf12a