### PR TITLE
Enhance damage animations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -341,10 +341,22 @@
   filter: brightness(1.3) sepia(1) hue-rotate(-50deg);
 }
 
+@keyframes pop-damage {
+  0% {
+    transform: scale(0.7);
+  }
+  50% {
+    transform: scale(1.4);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 @keyframes float-damage {
   0% {
     opacity: 1;
-    transform: translateY(0) scale(1.3);
+    transform: translateY(0);
   }
   100% {
     opacity: 0;
@@ -352,7 +364,9 @@
   }
 }
 .animate-float-damage {
-  animation: float-damage 1.6s ease-out forwards;
+  animation:
+    pop-damage 0.25s ease-out,
+    float-damage 1.35s ease-out forwards 0.25s;
 }
 
 @keyframes idleTwitch {

--- a/src/screens/BattleScreen.tsx
+++ b/src/screens/BattleScreen.tsx
@@ -450,7 +450,7 @@ const BattleScreen = ({ onQuit }: { onQuit: () => void }) => {
             <AbilityAnnouncement name={announcement.name} />
           )}
           {playerDamage !== null && (
-            <div className="absolute -top-6 left-1/2 transform -translate-x-1/2 text-red-500 text-3xl animate-float-damage glitch-text pointer-events-none">
+            <div className="absolute -top-6 left-1/2 transform -translate-x-1/2 text-red-500 text-5xl animate-float-damage glitch-text pointer-events-none">
               -{playerDamage}
             </div>
           )}
@@ -498,7 +498,7 @@ const BattleScreen = ({ onQuit }: { onQuit: () => void }) => {
             <AbilityAnnouncement name={announcement.name} />
           )}
           {enemyDamage !== null && (
-            <div className="absolute -top-6 left-1/2 transform -translate-x-1/2 text-red-500 text-3xl animate-float-damage glitch-text pointer-events-none">
+            <div className="absolute -top-6 left-1/2 transform -translate-x-1/2 text-red-500 text-5xl animate-float-damage glitch-text pointer-events-none">
               -{enemyDamage}
             </div>
           )}


### PR DESCRIPTION
## Summary
- add pop animation keyframes
- combine pop and float animations for damage numbers
- increase damage number font size

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68427a2d9890832cb6c7df72a9386c1e