### PR TITLE
Fix inventory useItem lint error and adjust tsconfig

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { test, expect } from 'vitest';

--- a/src/context/PlayerContext.tsx
+++ b/src/context/PlayerContext.tsx
@@ -63,7 +63,7 @@ interface PlayerContextValue {
   stats: Stats;
   equipped: { [K in 'Weapon' | 'Armor' | 'Trinket']?: Item };
   equip: (item: Item) => void;
-  useItem: (item: Item) => void;
+  consumeItem: (item: Item) => void;
   statusEffects: StatusEffect[];
 }
 
@@ -81,7 +81,7 @@ export const PlayerProvider = ({ children }: { children: React.ReactNode }) => {
     setEquipped(prev => ({ ...prev, [item.type]: item }));
   };
 
-  const useItem = (item: Item) => {
+  const consumeItem = (item: Item) => {
     if (item.heal) {
       setHP(prev => Math.min(baseStats.hp, prev + item.heal));
     }
@@ -99,7 +99,7 @@ export const PlayerProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <PlayerContext.Provider value={{ stats, equipped, equip, useItem, statusEffects }}>
+    <PlayerContext.Provider value={{ stats, equipped, equip, consumeItem, statusEffects }}>
       {children}
     </PlayerContext.Provider>
   );

--- a/src/screens/InventoryScreen.tsx
+++ b/src/screens/InventoryScreen.tsx
@@ -4,7 +4,7 @@ import { items, usePlayer } from '../context/PlayerContext';
 
 const InventoryScreen = () => {
   const navigate = useNavigate();
-  const { equip, useItem, equipped } = usePlayer();
+  const { equip, consumeItem, equipped } = usePlayer();
   const [selectedItemIndex, setSelectedItemIndex] = useState(0);
   const selected = items[selectedItemIndex];
 
@@ -54,7 +54,7 @@ const InventoryScreen = () => {
           <div className="mt-4">
             {selected.type === 'Consumable' ? (
               <button
-                onClick={() => useItem(selected)}
+                onClick={() => consumeItem(selected)}
                 className="border px-3 py-1 hover:bg-green-900"
               >
                 Use

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "jsx": "react-jsx"
+  },
   "exclude": [
     "frontend",
     "backend",


### PR DESCRIPTION
## Summary
- rename `useItem` to `consumeItem` to avoid mistaken hook call
- update InventoryScreen to use `consumeItem`
- allow React JSX & esModuleInterop via tsconfig
- tweak tests to import React using `* as`

## Testing
- `npm run build`
- `npm test -- -t boot`

------
https://chatgpt.com/codex/tasks/task_e_684282b28180832ca35e73e203767e5d