### PR TITLE
Improve tactical bot decision-making

### DIFF
--- a/backend/src/match_engine/bot_ai/tactical_bot.ts
+++ b/backend/src/match_engine/bot_ai/tactical_bot.ts
@@ -1,28 +1,59 @@
 import { PlayerState, TurnAction } from '../types';
 import { Ability } from '../../types/db';
-import { getAbilityById } from '../abilities';
+
+// Simple in-memory store so the bot can remember its last used ability
+const lastUsed: Record<string, string | null> = {};
 
 export function getAction(bot: PlayerState, opponent: PlayerState): TurnAction {
-  const usable = bot.abilities
-    .filter((a: Ability) => bot.energy >= (a.energy_cost || 0) && (!bot.cooldowns[a.id] || bot.cooldowns[a.id] === 0));
+  const usable = bot.abilities.filter(
+    (a: Ability) =>
+      bot.energy >= (a.energy_cost || 0) && (!bot.cooldowns[a.id] || bot.cooldowns[a.id] === 0)
+  );
 
-  const stun = usable.find((a: Ability) => a.effect_json?.type === 'stun');
-  const shield = usable.find((a: Ability) => a.effect_json?.type === 'shield');
-  const heavyHit = usable.find((a: Ability) => a.effect_json?.type === 'damage' && (a.effect_json?.value || 0) >= 40);
+  if (usable.length === 0) {
+    return { actorId: bot.id, abilityId: 'wait', targetId: opponent.id };
+  }
 
-  if (opponent.energy >= 50 && stun) {
-    return { actorId: bot.id, abilityId: stun.id, targetId: opponent.id };
-  }
-  if (bot.hp <= 50 && shield) {
-    return { actorId: bot.id, abilityId: shield.id, targetId: bot.id };
-  }
-  if (heavyHit) {
-    return { actorId: bot.id, abilityId: heavyHit.id, targetId: opponent.id };
-  }
+  const weighted = usable.map(a => {
+    let weight = 1;
+
+    switch (a.effect_json?.type) {
+      case 'stun':
+        weight += opponent.energy >= 50 ? 30 : 10;
+        break;
+      case 'shield':
+        weight += bot.hp <= 50 ? 20 : 5;
+        break;
+      case 'heal':
+        weight += bot.hp <= bot.maxHealth / 2 ? 25 : 5;
+        break;
+      case 'damage':
+        weight += a.effect_json?.value || 0;
+        if (opponent.hp <= 40) weight += 10;
+        break;
+    }
+
+    // Consider ability cooldown length - high cooldown abilities are valuable
+    weight += (a.cooldown || 0);
+
+    // Slightly discourage repeating the same ability twice in a row
+    if (lastUsed[bot.id] && lastUsed[bot.id] === a.id) {
+      weight -= 5;
+    }
+
+    return { ability: a, weight };
+  });
+
+  weighted.sort((a, b) => b.weight - a.weight);
+
+  const choice = weighted[0].ability;
+  lastUsed[bot.id] = choice.id;
+
+  const targetId = choice.effect_json?.target === 'self' ? bot.id : opponent.id;
 
   return {
     actorId: bot.id,
-    abilityId: usable[0]?.id || 'wait',
-    targetId: opponent.id
+    abilityId: choice.id,
+    targetId: targetId
   };
 }


### PR DESCRIPTION
## Summary
- give tactical bot a simple memory of last ability used
- add weighted selection for abilities including cooldown awareness

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in backend *(fails: no test specified)*
- `npm run build` in backend *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6843505f4470832c9a304e0be31b9a94