### PR TITLE
Fix cooldown tick per actor

### DIFF
--- a/backend/src/match_engine/resolver.test.ts
+++ b/backend/src/match_engine/resolver.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from 'vitest';
+import { runMatchTurn } from './resolver';
+import { initializePlayerState } from './state';
+import { getAbilityById } from './abilities';
+import type { MatchState, TurnAction } from './types';
+import type { PlayerProfile } from '../types/db';
+
+const fireball = getAbilityById('mage_fireball_uuid')!;
+
+function createProfile(id: string): PlayerProfile {
+  return {
+    id,
+    user_id: null,
+    character_class_id: null,
+    level: 1,
+    experience: 0,
+    unlocked_abilities: [],
+    equipped_cosmetic_id: null,
+    created_at: new Date(),
+  };
+}
+
+test('cooldowns decrement only for the acting player', () => {
+  const profileA = createProfile('A');
+  const profileB = createProfile('B');
+
+  let playerA = initializePlayerState(profileA, 'A', [fireball]);
+  let playerB = initializePlayerState(profileB, 'B', [fireball]);
+
+  // set a cooldown on playerB to verify it doesn't change on playerA's turn
+  playerB.cooldowns[fireball.id] = 2;
+
+  const matchState: MatchState = {
+    id: 'm1',
+    playerA,
+    playerB,
+    turnNumber: 1,
+    activePlayerId: playerA.profile.id,
+    combatLog: [],
+    status: 'active',
+    winnerId: null,
+    isBot: false,
+    turnLog: [],
+  };
+
+  const actionA: TurnAction = {
+    actorId: playerA.profile.id,
+    abilityId: fireball.id,
+    targetId: playerB.profile.id,
+  };
+
+  const { updatedMatchState: afterA } = runMatchTurn(matchState, actionA);
+
+  expect(afterA.playerA.cooldowns[fireball.id]).toBeUndefined();
+  expect(afterA.playerB.cooldowns[fireball.id]).toBe(2);
+});

--- a/backend/src/match_engine/resolver.ts
+++ b/backend/src/match_engine/resolver.ts
@@ -56,8 +56,6 @@ export const runMatchTurn = (matchState: MatchState, turnAction: TurnAction): Ma
     actor.cooldowns[abilityId] = (ability.cooldown || 0);
 
     // Apply ability effects
-    // Apply ability effects
-    const effectsAppliedForLog: StatusEffect[] = []; // To collect effects for turn log
 
     if (ability.effects && ability.effects.length > 0) {
       ability.effects.forEach(effectJson => {
@@ -115,12 +113,7 @@ export const runMatchTurn = (matchState: MatchState, turnAction: TurnAction): Ma
   target = processStatusEffects(target);
 
   // Cooldown Ticker Per Turn
-  actor.cooldowns = Object.fromEntries(
-    Object.entries(actor.cooldowns).map(([key, val]) => [key, Math.max(0, val - 1)])
-  );
-  target.cooldowns = Object.fromEntries(
-    Object.entries(target.cooldowns).map(([key, val]) => [key, Math.max(0, val - 1)])
-  );
+  actor = decrementCooldowns(actor);
 
   // Update match state with new player states
   let updatedMatchState = {


### PR DESCRIPTION
## Summary
- remove duplicate `effectsAppliedForLog` declaration in resolver
- tick down cooldowns only for the acting player
- add regression test for per-actor cooldown handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843512c292c832cb6a557bb9c0317ee