### PR TITLE
Add start/end turn hooks for status effects

### DIFF
--- a/backend/src/match_engine/resolver.ts
+++ b/backend/src/match_engine/resolver.ts
@@ -3,7 +3,7 @@ import { applyDamage, applyEnergyCost, updatePlayerState, decrementCooldowns, up
 import { addLogEntry } from './combat_log';
 import { Ability, EffectJson } from '../types/db'; // Import EffectJson
 import { getAbilityById } from './abilities'; // Import getAbilityById
-import { applyStatus, hasStatus, processStatusEffects, applyEffect } from './status_manager'; // Import status manager functions
+import { applyStatus, hasStatus, processStatusEffects, applyEffect, triggerStartTurn, triggerEndTurn } from './status_manager';
 import { BotModels } from './bot_ai/index'; // Import BotModels
 import { v4 as uuidv4 } from 'uuid'; // Import uuid for generating unique IDs
 
@@ -13,6 +13,9 @@ export const runMatchTurn = (matchState: MatchState, turnAction: TurnAction): Ma
   let target = matchState.playerA.profile.id === targetId ? matchState.playerA : matchState.playerB;
   let combatLog: CombatLogEntry[] = [];
   const effectsAppliedForLog: StatusEffect[] = []; // To collect effects for turn log
+
+  // Trigger start-of-turn effects for the acting player
+  actor = triggerStartTurn(actor);
 
   // If playerB is a bot, determine its action
   if (matchState.playerB.isBot && actor.profile.id === matchState.playerB.profile.id) {
@@ -113,6 +116,9 @@ export const runMatchTurn = (matchState: MatchState, turnAction: TurnAction): Ma
   // Process status effects for both players at the end of their turn
   actor = processStatusEffects(actor);
   target = processStatusEffects(target);
+
+  // Trigger end-of-turn effects for the acting player
+  actor = triggerEndTurn(actor);
 
   // Cooldown Ticker Per Turn
   actor.cooldowns = Object.fromEntries(

--- a/backend/src/match_engine/status_manager.ts
+++ b/backend/src/match_engine/status_manager.ts
@@ -118,3 +118,23 @@ function consumeShield(effects: StatusEffect[], incomingDamage: number): StatusE
 
   return updated.filter((e) => e.type !== 'shield' || (e.value || 0) > 0);
 }
+
+export function triggerStartTurn(player: PlayerState): PlayerState {
+  let updated = { ...player };
+  for (const effect of player.statusEffects) {
+    if (typeof effect.onStartTurn === 'function') {
+      updated = effect.onStartTurn(updated, effect);
+    }
+  }
+  return updated;
+}
+
+export function triggerEndTurn(player: PlayerState): PlayerState {
+  let updated = { ...player };
+  for (const effect of player.statusEffects) {
+    if (typeof effect.onEndTurn === 'function') {
+      updated = effect.onEndTurn(updated, effect);
+    }
+  }
+  return updated;
+}

--- a/backend/src/match_engine/types.ts
+++ b/backend/src/match_engine/types.ts
@@ -73,6 +73,10 @@ export interface StatusEffect {
   appliedAtTurn: number;
   value?: number; // For damage, heal, shield, buff values
   stat?: string; // For buffs (e.g., 'defense', 'attack')
+  /** Callback triggered when the owning player starts their turn */
+  onStartTurn?: (player: PlayerState, effect: StatusEffect) => PlayerState;
+  /** Callback triggered when the owning player ends their turn */
+  onEndTurn?: (player: PlayerState, effect: StatusEffect) => PlayerState;
   [key: string]: any; // Allow other properties
   // Add more properties like potency, tickDamage, etc.
 }

--- a/match_resolution_engine_architecture.md
+++ b/match_resolution_engine_architecture.md
@@ -41,6 +41,7 @@ runEffect({ type: 'burn', duration: 2 }, abilityId, source, target, state)
   - Buffs/debuffs
   - Immunities, shields, damage-over-time
 - Clears expired effects
+ - Triggers optional `onStartTurn`/`onEndTurn` callbacks on each status effect
 
 ### `validator.ts`
 - Verifies submitted turn legality:
@@ -80,7 +81,7 @@ runEffect({ type: 'burn', duration: 2 }, abilityId, source, target, state)
      ↓
 [effect_runner.ts]
      ↓
-[status_manager.ts] → updates effects
+[status_manager.ts] → updates effects and fires turn triggers
      ↓
 [combat_log.ts] → writes log
      ↓


### PR DESCRIPTION
## Summary
- extend `StatusEffect` with `onStartTurn` and `onEndTurn`
- add trigger helpers in `status_manager` to call the turn hooks
- invoke the triggers from `runMatchTurn`
- document the new callbacks in architecture notes

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684351338748832cb84b9454ae3546b5