### PR TITLE
Add logging for invalid turns

### DIFF
--- a/backend/src/match_engine/validator.ts
+++ b/backend/src/match_engine/validator.ts
@@ -1,12 +1,44 @@
 import { MatchState, TurnAction } from './types';
 
-export const validateTurn = (matchState: MatchState, turnAction: TurnAction): boolean => {
-  // TODO: Implement comprehensive validation logic
-  // - Check if it's the acting player's turn
-  // - Check if ability is unlocked
-  // - Check if ability is on cooldown
-  // - Check if player is silenced/stunned
-  // - Check if target is valid
-  console.log(`Validating turn for player ${turnAction.actorId} using ability ${turnAction.abilityId}`);
-  return true; // Placeholder for now
+export interface ValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export const validateTurn = (
+  matchState: MatchState,
+  turnAction: TurnAction
+): ValidationResult => {
+  const actor =
+    matchState.playerA.profile.id === turnAction.actorId
+      ? matchState.playerA
+      : matchState.playerB;
+
+  if (matchState.activePlayerId !== turnAction.actorId) {
+    return { valid: false, reason: "It's not your turn" };
+  }
+
+  const ability = actor.abilities.find(a => a.id === turnAction.abilityId);
+  if (!ability) {
+    return { valid: false, reason: 'Ability not available' };
+  }
+
+  if (actor.cooldowns[turnAction.abilityId] && actor.cooldowns[turnAction.abilityId] > 0) {
+    return { valid: false, reason: 'Ability on cooldown' };
+  }
+
+  if (actor.energy < (ability.energy_cost || 0)) {
+    return { valid: false, reason: 'Not enough energy' };
+  }
+
+  if (actor.statusEffects.some(e => e.type === 'stun')) {
+    return { valid: false, reason: 'You are stunned' };
+  }
+
+  const validTargets = [matchState.playerA.profile.id, matchState.playerB.profile.id];
+  if (!validTargets.includes(turnAction.targetId)) {
+    return { valid: false, reason: 'Invalid target' };
+  }
+
+  return { valid: true };
 };


### PR DESCRIPTION
## Summary
- enhance `validateTurn` to report reason for invalid moves
- call `validateTurn` for player A, player B and bot actions
- when validation fails, log using `addLogEntry`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684351377240832c88abe3d93112eab5