### PR TITLE
Add status effect icons

### DIFF
--- a/src/components/StatusEffectIcon.tsx
+++ b/src/components/StatusEffectIcon.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+import {
+  Flame,
+  Bolt,
+  Shield,
+  ArrowUpCircle,
+  ArrowDownCircle,
+  Biohazard,
+} from 'lucide-react';
+import type { StatusEffectType } from '../context/PlayerContext';
+
+const iconMap: Record<StatusEffectType, LucideIcon> = {
+  burn: Flame,
+  stun: Bolt,
+  shield: Shield,
+  buff: ArrowUpCircle,
+  debuff: ArrowDownCircle,
+  poison: Biohazard,
+};
+
+interface StatusEffectIconProps {
+  type: StatusEffectType;
+  size?: number | string;
+  className?: string;
+}
+
+const StatusEffectIcon: React.FC<StatusEffectIconProps> = ({ type, size = 16, className }) => {
+  const Icon = iconMap[type];
+  return <Icon size={size} className={className} />;
+};
+
+export default StatusEffectIcon;

--- a/src/screens/BattleScreen.tsx
+++ b/src/screens/BattleScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import AbilityAnnouncement from '../components/AbilityAnnouncement';
 import AttackEffect from '../components/AttackEffect';
+import StatusEffectIcon from '../components/StatusEffectIcon';
 import { useNavigate } from 'react-router-dom'; // New import
 import { EndBattleScreen } from './EndBattleScreen'; // New import
 
@@ -545,8 +546,9 @@ const BattleScreen = ({ onQuit }: { onQuit: () => void }) => {
             {playerStatusEffects.map((effect, i) => (
               <div
                 key={i}
-                className={`text-xs px-2 py-0.5 rounded bg-green-900 border border-green-400 font-mono glitch ${effectColors[effect.type]}`}
+                className={`flex items-center text-xs px-2 py-0.5 rounded bg-green-900 border border-green-400 font-mono glitch ${effectColors[effect.type]}`}
               >
+                <StatusEffectIcon type={effect.type} size={14} className="mr-1" />
                 {effect.type.toUpperCase()} ({effect.duration})
               </div>
             ))}
@@ -602,8 +604,9 @@ const BattleScreen = ({ onQuit }: { onQuit: () => void }) => {
             {enemyStatusEffects.map((effect, i) => (
               <div
                 key={i}
-                className={`text-xs px-2 py-0.5 rounded bg-red-900 border border-red-400 font-mono glitch ${effectColors[effect.type]}`}
+                className={`flex items-center text-xs px-2 py-0.5 rounded bg-red-900 border border-red-400 font-mono glitch ${effectColors[effect.type]}`}
               >
+                <StatusEffectIcon type={effect.type} size={14} className="mr-1" />
                 {effect.type.toUpperCase()} ({effect.duration})
               </div>
             ))}


### PR DESCRIPTION
## Summary
- add `StatusEffectIcon` component that maps effects to lucide icons
- show status effect icons on BattleScreen

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843520d4400832c84245bd360201b9b