### PR TITLE
Create shared status effect type

### DIFF
--- a/src/context/PlayerContext.tsx
+++ b/src/context/PlayerContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import type { StatusEffect, StatusEffectType } from '../types/statusEffects';
 
 export interface Stats {
   hp: number;
@@ -8,14 +9,6 @@ export interface Stats {
   def: number;
 }
 
-export type StatusEffectType = 'burn' | 'stun' | 'shield' | 'buff' | 'debuff' | 'poison';
-
-export interface StatusEffect {
-  type: StatusEffectType;
-  duration: number;
-  value?: number;
-  stat?: string;
-}
 
 export interface Item {
   name: string;

--- a/src/screens/BattleScreen.tsx
+++ b/src/screens/BattleScreen.tsx
@@ -6,22 +6,7 @@ import { useNavigate } from 'react-router-dom'; // New import
 import { EndBattleScreen } from './EndBattleScreen'; // New import
 import { items, Item } from '../context/PlayerContext';
 import { runItemEffect, BattleState } from '../ItemEffectRunner';
-
-type StatusEffectType =
-  | 'burn'
-  | 'stun'
-  | 'shield'
-  | 'buff'
-  | 'debuff'
-  | 'poison';
-
-interface StatusEffect {
-  type: StatusEffectType;
-  duration: number; // in turns
-  value?: number; // For damage, heal, shield, buff values
-  stat?: string; // For buffs (e.g., 'defense', 'attack')
-  justApplied?: boolean; // Flag to skip duration tick on the turn it's applied
-}
+import type { StatusEffect, StatusEffectType } from '../types/statusEffects';
 
 type Ability = {
   name: string;

--- a/src/types/statusEffects.ts
+++ b/src/types/statusEffects.ts
@@ -1,0 +1,15 @@
+export type StatusEffectType =
+  | 'burn'
+  | 'stun'
+  | 'shield'
+  | 'buff'
+  | 'debuff'
+  | 'poison';
+
+export interface StatusEffect {
+  type: StatusEffectType;
+  duration: number; // in turns
+  value?: number; // For damage, heal, shield, buff values
+  stat?: string; // For buffs (e.g., 'defense', 'attack')
+  justApplied?: boolean; // Flag to skip duration tick when first applied
+}


### PR DESCRIPTION
## Summary
- centralize `StatusEffectType` definition under `src/types`
- import the shared type in `BattleScreen` and `PlayerContext`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68436384edb4832c9590f5c0b753a5ae