### PR TITLE
Add backend match engine tests

### DIFF
--- a/backend/src/match_engine/cooldown_logic.test.ts
+++ b/backend/src/match_engine/cooldown_logic.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from 'vitest';
+import { runMatchTurn } from './resolver';
+import { initializePlayerState } from './state';
+import { getAbilityById } from './abilities';
+import type { MatchState, TurnAction } from './types';
+import type { PlayerProfile } from '../types/db';
+
+const meteorCharge = getAbilityById('meteor_charge')!;
+const slash = getAbilityById('warrior_slash_uuid')!;
+
+function createProfile(id: string): PlayerProfile {
+  return {
+    id,
+    user_id: null,
+    character_class_id: null,
+    level: 1,
+    experience: 0,
+    unlocked_abilities: [],
+    equipped_cosmetic_id: null,
+    created_at: new Date(),
+  };
+}
+
+test('cooldown prevents ability reuse until turns pass', () => {
+  const profileA = createProfile('A');
+  const profileB = createProfile('B');
+
+  let playerA = initializePlayerState(profileA, 'A', [meteorCharge, slash]);
+  let playerB = initializePlayerState(profileB, 'B', [slash]);
+
+  const baseState: MatchState = {
+    id: 'm1',
+    playerA,
+    playerB,
+    turnNumber: 1,
+    activePlayerId: playerA.profile.id,
+    combatLog: [],
+    status: 'active',
+    winnerId: null,
+    isBot: false,
+    turnLog: [],
+  };
+
+  const actionA1: TurnAction = {
+    actorId: playerA.profile.id,
+    abilityId: 'meteor_charge',
+    targetId: playerB.profile.id,
+  };
+
+  let { updatedMatchState: state1 } = runMatchTurn(baseState, actionA1);
+  expect(state1.playerA.cooldowns['meteor_charge']).toBe(1);
+
+  const actionB: TurnAction = {
+    actorId: playerB.profile.id,
+    abilityId: slash.id,
+    targetId: playerA.profile.id,
+  };
+  let { updatedMatchState: state2 } = runMatchTurn(state1, actionB);
+  expect(state2.playerA.cooldowns['meteor_charge']).toBe(1);
+
+  const actionA2: TurnAction = {
+    actorId: playerA.profile.id,
+    abilityId: 'meteor_charge',
+    targetId: playerB.profile.id,
+  };
+  const attempt = runMatchTurn(state2, actionA2);
+  expect(attempt.updatedMatchState).toBe(state2);
+  expect(attempt.updatedMatchState.playerA.cooldowns['meteor_charge']).toBe(1);
+
+  const altAction: TurnAction = {
+    actorId: playerA.profile.id,
+    abilityId: slash.id,
+    targetId: playerB.profile.id,
+  };
+  let { updatedMatchState: state3 } = runMatchTurn(state2, altAction);
+  expect(state3.playerA.cooldowns['meteor_charge']).toBeUndefined();
+});

--- a/backend/src/match_engine/status_manager.test.ts
+++ b/backend/src/match_engine/status_manager.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from 'vitest';
+import { initializePlayerState } from './state';
+import { applyEffect, processStatusEffects } from './status_manager';
+import type { PlayerProfile } from '../types/db';
+import type { StatusEffect } from './types';
+
+function createProfile(id: string): PlayerProfile {
+  return {
+    id,
+    user_id: null,
+    character_class_id: null,
+    level: 1,
+    experience: 0,
+    unlocked_abilities: [],
+    equipped_cosmetic_id: null,
+    created_at: new Date(),
+  };
+}
+
+test('burn effect deals damage over its duration', () => {
+  const profile = createProfile('A');
+  let player = initializePlayerState(profile, 'A', []);
+
+  const burn: StatusEffect = {
+    id: 'burn1',
+    type: 'burn',
+    duration: 2,
+    sourceAbilityId: 'spell',
+    appliedAtTurn: 1,
+    value: 5,
+  };
+
+  player = applyEffect(player, burn);
+
+  player = processStatusEffects(player);
+  expect(player.hp).toBe(95);
+  expect(player.statusEffects[0].duration).toBe(1);
+
+  player = processStatusEffects(player);
+  expect(player.hp).toBe(90);
+  expect(player.statusEffects.length).toBe(0);
+});

--- a/backend/src/match_engine/victory_checker.test.ts
+++ b/backend/src/match_engine/victory_checker.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from 'vitest';
+import { checkVictoryCondition } from './victory_checker';
+import { initializePlayerState } from './state';
+import type { MatchState } from './types';
+import type { PlayerProfile } from '../types/db';
+
+function createProfile(id: string): PlayerProfile {
+  return {
+    id,
+    user_id: null,
+    character_class_id: null,
+    level: 1,
+    experience: 0,
+    unlocked_abilities: [],
+    equipped_cosmetic_id: null,
+    created_at: new Date(),
+  };
+}
+
+test('checkVictoryCondition detects KO', () => {
+  const profileA = createProfile('A');
+  const profileB = createProfile('B');
+
+  const playerA = { ...initializePlayerState(profileA, 'A', []), hp: 0 };
+  const playerB = initializePlayerState(profileB, 'B', []);
+
+  const matchState: MatchState = {
+    id: 'm1',
+    playerA,
+    playerB,
+    turnNumber: 1,
+    activePlayerId: playerA.profile.id,
+    combatLog: [],
+    status: 'active',
+    winnerId: null,
+    isBot: false,
+    turnLog: [],
+  };
+
+  const result = checkVictoryCondition(matchState);
+  expect(result.isGameOver).toBe(true);
+  expect(result.winnerId).toBe(playerB.profile.id);
+});


### PR DESCRIPTION
## Summary
- test burn status effect in match engine
- ensure ability cooldown logic works as expected
- verify victory checker detects a KO

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843671514e8832c9c96a52461bb89ad