### PR TITLE
Implement victory and disconnect handling

### DIFF
--- a/backend/src/match_engine/victory_checker.ts
+++ b/backend/src/match_engine/victory_checker.ts
@@ -1,4 +1,7 @@
-import { MatchState, PlayerState } from './types';
+import { MatchState } from './types';
+
+// Maximum number of turns before a match times out
+const MAX_TURNS = 50;
 
 export const checkVictoryCondition = (matchState: MatchState): { isGameOver: boolean; winnerId: string | null } => {
   // Check for KO
@@ -9,8 +12,22 @@ export const checkVictoryCondition = (matchState: MatchState): { isGameOver: boo
   if (matchState.playerB.hp <= 0) {
     return { isGameOver: true, winnerId: matchState.playerA.profile.id };
   }
-  // TODO: Implement timeout condition
-  // TODO: Implement forfeit condition
+  // Timeout: if the turn limit is exceeded, winner is the player with higher HP
+  if (matchState.turnNumber > MAX_TURNS) {
+    const { playerA, playerB } = matchState;
+    let winnerId: string | null = null;
+
+    if (playerA.hp !== playerB.hp) {
+      winnerId = playerA.hp > playerB.hp ? playerA.profile.id : playerB.profile.id;
+    }
+
+    return { isGameOver: true, winnerId };
+  }
+
+  // Forfeit: if match status has been set to 'forfeit', respect the stored winner
+  if (matchState.status === 'forfeit') {
+    return { isGameOver: true, winnerId: matchState.winnerId };
+  }
 
   return { isGameOver: false, winnerId: null };
 };


### PR DESCRIPTION
## Summary
- implement timeout and forfeit checks in `victory_checker`
- gracefully handle player disconnects and mark matches as forfeit

## Testing
- `npx vitest run --reporter=verbose`

------
https://chatgpt.com/codex/tasks/task_e_6843670da048832c9948cf71e33ec430